### PR TITLE
Switch to std futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ repository = "https://github.com/paritytech/exit-future"
 license = "MIT"
 
 [dependencies]
-futures = "0.1.25"
+futures = "0.3.1"
 parking_lot = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,4 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.1"
-parking_lot = "0.7.1"
-
-[dev-dependencies]
-futures = { version = "0.3.1", features = ["compat"] }
-futures01 = { package = "futures", version = "0.1" }
+parking_lot = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,7 @@ edition = "2018"
 [dependencies]
 futures = "0.3.1"
 parking_lot = "0.7.1"
+
+[dev-dependencies]
+futures = { version = "0.3.1", features = ["compat"] }
+futures01 = { package = "futures", version = "0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,3 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.1"
-parking_lot = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "exit-future"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Future that signals exit to many receivers"
 repository = "https://github.com/paritytech/exit-future"
 license = "MIT"
+edition = "2018"
 
 [dependencies]
 futures = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## [Documentation](https://docs.rs/exit-future)
 ----
 
-Create a `Signal` and cloneable `Exit` future that fires when `Signal` is fired or dropped. Used to coordinate exit between multiple event-loop threads.
+Create a `Signal` and cloneable `Exit` future that fires when `Signal` is fired. Used to coordinate exit between multiple event-loop threads.
 
 ```rust
 use futures::executor::block_on;
@@ -12,5 +12,5 @@ let (signal, exit) = exit_future::signal();
     block_on(exit);
 });
 
-signal.fire(); // also would fire on drop.
+let _ = signal.fire();
 ```

--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@
 Create a `Signal` and cloneable `Exit` future that fires when `Signal` is fired or dropped. Used to coordinate exit between multiple event-loop threads.
 
 ```rust
-use futures::executor::block_on;
 let (signal, exit) = exit_future::signal();
 
 ::std::thread::spawn(move || {
     // future resolves when signal fires
-    block_on(exit);
+    exit.wait();
 });
 
 signal.fire(); // also would fire on drop.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 Create a `Signal` and cloneable `Exit` future that fires when `Signal` is fired or dropped. Used to coordinate exit between multiple event-loop threads.
 
 ```rust
+use futures::executor::block_on;
 let (signal, exit) = exit_future::signal();
 
 ::std::thread::spawn(move || {
     // future resolves when signal fires
-    exit.wait().unwrap();
+    block_on(exit);
 });
 
 signal.fire(); // also would fire on drop.

--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ let (signal, exit) = exit_future::signal();
     exit.wait();
 });
 
-let _ = signal.fire();
+let _ = signal.fire(); // also would fire on drop.
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## [Documentation](https://docs.rs/exit-future)
 ----
 
-Create a `Signal` and cloneable `Exit` future that fires when `Signal` is fired. Used to coordinate exit between multiple event-loop threads.
+Create a `Signal` and cloneable `Exit` future that fires when `Signal` is fired or dropped.
+Used to coordinate exit between multiple event-loop threads.
 
 ```rust
 let (signal, exit) = exit_future::signal();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,215 +1,59 @@
 extern crate futures;
 extern crate parking_lot;
 
-use parking_lot::Mutex;
-use futures::prelude::*;
-use futures::task::{self, Task, AtomicTask};
-use futures::executor::{self, Notify};
-
-use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::pin::Pin;
+use std::task::{Poll, Context};
+use std::ops::DerefMut;
+use futures::{Future, FutureExt, channel::oneshot, future::{select, Either}, executor::block_on};
+use parking_lot::Mutex;
 
-/// Future that resolves when inner work finishes or on exit signal firing.
 #[derive(Clone)]
-pub struct UntilExit<F> {
-    inner: F,
-    exit: Exit,
-}
+pub struct Exit(Arc<Mutex<oneshot::Receiver<()>>>);
 
-impl<F: Future> Future for UntilExit<F> {
-    type Item = Option<F::Item>;
-    type Error = F::Error;
+impl Future for Exit {
+    type Output = ();
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.inner.poll() {
-            Ok(Async::Ready(x)) => Ok(Async::Ready(Some(x))),
-            Ok(Async::NotReady) => Ok(self.exit.check().map(|()| None)),
-            Err(e) => Err(e),
-        }
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let mut receiver = Pin::into_inner(self).0.lock();
+        Pin::new(receiver.deref_mut()).poll(cx).map(|_| ())
     }
-}
-
-struct Notifier {
-    signalled: AtomicBool,
-    outer_task: AtomicTask,
-}
-
-impl Notify for Notifier {
-    // id isn't necessary because this is a notifier for a single
-    // exit future.
-    fn notify(&self, _: usize) {
-        self.signalled.store(true, Ordering::Release);
-        self.outer_task.notify()
-    }
-}
-
-struct ExitInner {
-    shared_id: usize,
-    notifier: Arc<Notifier>,
-}
-
-impl ExitInner {
-    fn check(&self, shared: &Shared) -> Async<()> {
-        // set up the outer task correctly so when the inner
-        // task is notified, we get woken up.
-        self.notifier.outer_task.register();
-
-        // if any poll was signalled by the inner task, use it.
-        if !self.notifier.signalled.fetch_and(false, Ordering::SeqCst) {
-            return Async::NotReady
-        }
-
-        // do heavy check with inner task. ID doesn't matter.
-        executor::with_notify(&self.notifier, 0, || {
-            if shared.is_live_and_notify(self.shared_id) {
-                Async::NotReady
-            } else {
-                Async::Ready(())
-            }
-        })
-    }
-}
-
-/// Future that resolves when the exit signal has fired.
-pub struct Exit {
-    inner: Option<ExitInner>,
-    shared: Arc<Shared>,
 }
 
 impl Exit {
-    /// Check if the signal is live outside of the context of a task and 
-    /// without scheduling a wakeup.
     pub fn is_live(&self) -> bool {
-        self.shared.waiting.lock().0
+        self.0.lock().try_recv().is_ok()
     }
 
-    /// Perform given work until complete.
-    pub fn until<F: IntoFuture>(self, f: F) -> UntilExit<F::Future> {
-        UntilExit {
-            inner: f.into_future(),
-            exit: self,
-        }
-    } 
+    pub fn until<F: Future + Unpin>(self, future: F) -> impl Future<Output = Option<F::Output>> {
+        select(self, future)
+            .map(|either| match either {
+                Either::Left(_) => None,
+                Either::Right((output, _)) => Some(output)
+            })
+    }
 
-    fn check(&mut self) -> Async<()> {
-        let shared = &self.shared;
-
-        // lazily register and initialize.
-        let inner = self.inner.get_or_insert_with(|| {
-            let shared_id = shared.register();
-            let notifier = Arc::new(Notifier {
-                // ensure an initial poll happens.
-                signalled: AtomicBool::new(true),
-                outer_task: AtomicTask::new(),
-            });
-
-            ExitInner { shared_id, notifier }
-        });
-
-        inner.check(shared)
+    pub fn wait(self) {
+        block_on(self)
     }
 }
 
-impl Future for Exit {
-    type Item = ();
-    type Error = ();
-
-    fn poll(&mut self) -> Poll<(), ()> {
-        Ok(self.check())
-    }
-}
-
-impl Clone for Exit {
-    fn clone(&self) -> Exit {
-        Exit { inner: None, shared: self.shared.clone() }
-    }
-}
-
-struct Shared {
-    count: AtomicUsize,
-    waiting: Mutex<(bool, HashMap<usize, Task>)>,
-}
-
-impl Shared {
-    fn set(&self) {
-        let wake_up = {
-            let mut waiting = self.waiting.lock();
-            waiting.0 = false;
-            ::std::mem::replace(&mut waiting.1, HashMap::new())
-        };
-
-        for (_, task) in wake_up {
-            task.notify()
-        }
-    }
-
-    fn register(&self) -> usize {
-        self.count.fetch_add(1, Ordering::Relaxed)
-    }
-
-    // should be called only in the context of a task.
-    // returns whether the exit counter is live.
-    fn is_live_and_notify(&self, id: usize) -> bool {
-        let mut waiting = self.waiting.lock();
-
-        if waiting.0 {
-            let _ = waiting.1.insert(id, task::current());
-        }
-
-        waiting.0
-    }
-}
-
-/// Exit signal that fires either manually or on drop.
-pub struct Signal {
-    shared: Arc<Shared>,
-}
+pub struct Signal(oneshot::Sender<()>);
 
 impl Signal {
-    fn fire_inner(&mut self) {
-        self.shared.set();
-    }
-
-    /// Fire the signal manually.
-    pub fn fire(mut self) {
-        self.fire_inner()
-    }
-
-    /// Get an exit future.
-    pub fn make_exit(&self) -> Exit {
-        Exit { inner: None, shared: self.shared.clone() }
+    pub fn fire(self) -> Result<(), ()> {
+        self.0.send(())
     }
 }
 
-impl Drop for Signal {
-    fn drop(&mut self) {
-        self.fire_inner()
-    }
-}
-
-/// Create a signal and exit pair. `Exit` is a future that resolves when the
-/// `Signal` object is either dropped or has `fire` called on it.
 pub fn signal() -> (Signal, Exit) {
-    let signal = signal_only();
-    let exit = signal.make_exit();
-
-    (signal, exit)
-}
-
-/// Create only a signal.
-pub fn signal_only() -> Signal {
-    let shared = Arc::new(Shared {
-        count: AtomicUsize::new(1),
-        waiting: Mutex::new((true, HashMap::new())),
-    });
-
-    Signal { shared }
+    let (sender, receiver) = oneshot::channel();
+    (Signal(sender), Exit(Arc::new(Mutex::new(receiver))))
 }
 
 #[cfg(test)]
 mod tests {
-    use futures::future;
+    use futures::future::{join3, ready, pending, lazy};
     use super::*;
 
     #[test]
@@ -223,17 +67,19 @@ mod tests {
         let barrier = Arc::new(::std::sync::Barrier::new(2));
         let thread_barrier = barrier.clone();
         let handle = ::std::thread::spawn(move || {
-            let barrier = ::futures::future::lazy(move || { thread_barrier.wait(); Ok(()) });
+            let barrier = ::futures::future::lazy(move |_| {
+                thread_barrier.wait();
+            });
 
-            assert!(exit_a.join3(exit_b, barrier).wait().is_ok());
+            block_on(join3(exit_a, exit_b, barrier));
         });
 
         barrier.wait();
-        signal.fire();
+        signal.fire().unwrap();
 
         let _ = handle.join();
         assert!(!exit_c.is_live());
-        assert!(exit_c.wait().is_ok());
+        exit_c.wait()
     }
 
     #[test]
@@ -247,12 +93,12 @@ mod tests {
     #[test]
     fn work_until() {
         let (signal, exit) = signal();
-        let work_a = exit.clone().until(future::ok::<_, ()>(5));
-        assert_eq!(work_a.wait().unwrap(), Some(5));
+        let work_a = exit.clone().until(ready(5));
+        assert_eq!(block_on(work_a), Some(5));
 
-        signal.fire();
-        let work_b = exit.until(::futures::future::empty::<(), ()>());
-        assert_eq!(work_b.wait().unwrap(), None);
+        signal.fire().unwrap();
+        let work_b = exit.until(pending::<()>());
+        assert_eq!(block_on(work_b), None);
     }
 
     #[test]
@@ -261,26 +107,23 @@ mod tests {
 
         ::std::thread::spawn(move || {
             ::std::thread::sleep(::std::time::Duration::from_millis(2500));
-            signal.fire();
+            signal.fire().unwrap();
         });
 
-        exit.wait().unwrap();
+        block_on(exit);
     }
 
     #[test]
     fn clone_works() {
         let (_signal, mut exit) = signal();
 
-        future::lazy(move || {
-            exit.poll().unwrap();
-            assert!(exit.inner.is_some());
-            
-            let mut exit2 = exit.clone();
-            assert!(exit2.inner.is_none());
-            exit2.poll().unwrap();
+        let future = lazy(move |cx| {
+            let _ = Pin::new(&mut exit).poll(cx);
 
-            assert!(exit.inner.unwrap().shared_id != exit2.inner.unwrap().shared_id);
-            future::ok::<(), ()>(())
-        }).wait().unwrap();
+            let mut exit2 = exit.clone();
+            let _ = Pin::new(&mut exit2).poll(cx);
+        });
+
+        block_on(future)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,27 +167,4 @@ mod tests {
 
         block_on(future)
     }
-
-    #[test]
-    fn compat_works() {
-        use futures01::Future;
-        use futures::TryFutureExt;
-
-        let (_sender, recv) = futures01::sync::oneshot::channel();
-        let (signal, exit) = signal();
-
-        let handle = spawn(move || {
-            sleep(Duration::from_secs(1));
-            signal.fire().unwrap();
-        });
-
-        let _ = recv
-            .select(exit.clone().map(Ok).compat())
-            .wait()
-            .unwrap_or_else(|_| panic!());
-
-        exit.wait();
-
-        handle.join().unwrap();
-    }
 }


### PR DESCRIPTION
I've changed the internals to use a `oneshot` sender/receiver pair which seems to work the same but with (a lot) less code.